### PR TITLE
Add psycopg2 as master requirement

### DIFF
--- a/piwheels/__init__.py
+++ b/piwheels/__init__.py
@@ -65,7 +65,7 @@ __requires__ = ['configargparse', 'pyzmq']
 
 __extra_requires__ = {
     'monitor': ['urwid'],
-    'master':  ['sqlalchemy'],
+    'master':  ['sqlalchemy', 'psycopg2'],
     'slave':   ['pip', 'wheel', 'python-dateutil'],
     'test':    ['pytest', 'coverage'],
     'doc':     ['sphinx'],


### PR DESCRIPTION
It seems `psycopg2` is also required for the master. Correct?