### PR TITLE
Add libcurl4-openssl-dev to allow building of pycurl, close #49

### DIFF
--- a/deploy_slave.sh
+++ b/deploy_slave.sh
@@ -17,9 +17,9 @@ apt -y install python3-zmq python-dev python3-dev zlib1g-dev $LIBPNG_DEV \
     $LIBMYSQL_DEV libpq-dev libffi-dev libxml2-dev libxslt-dev libgmp-dev \
     libhdf5-dev libldap2-dev libjpeg-dev libbluetooth-dev libusb-dev \
     libhidapi-dev libfreetype6-dev liblcms2-dev libzbar-dev libbz2-dev \
-    libblas-dev liblapack-dev liblapacke-dev libgles2-mesa-dev \
+    libblas-dev liblapack-dev liblapacke-dev libgles2-mesa-dev libcurl4-openssl-dev \
     libgles1-mesa-dev libgstreamer1.0-dev libsdl2-dev libssl-dev libsasl2-dev \
-    libldap2-dev libavcodec-dev libavformat-dev libswscale-dev libv4l-dev
+    libldap2-dev libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
     libxvidcore-dev libx264-dev libgtk2.0-dev libgtk-3-dev libatlas-base-dev \
     python-numpy python3-numpy python-scipy python3-scipy python-matplotlib \
     python3-matplotlib python-pandas python3-pandas cython cython3 \


### PR DESCRIPTION
`pycurl` is currently not available on piwheels, so I opened #49 and tried to build it on my Pi today.

It turns out that `libcurl4-openssl-dev` is required to build pycurl on Raspbian. This PR adds it to `deploy_slave.sh`.
Also there was a backslash missing in the `apt install` command, so I added it.