### PR TITLE
Fix #70

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ develop: tags
 	@# These have to be done separately to avoid a cockup...
 	$(PIP) install -U setuptools
 	$(PIP) install -U pip
-	$(PIP) install -e .[doc,test]
+	$(PIP) install -e .[doc,test,master,slave,monitor,log]
 
 test:
 	$(COVERAGE) run -m $(PYTEST) tests -v

--- a/piwheels/importer/__init__.py
+++ b/piwheels/importer/__init__.py
@@ -117,9 +117,9 @@ node as the piw-master script.
         ]
         builder = PiWheelsBuilder(
             config.package if config.package is not None else
-            packages[0].metadata['name'],
+            packages[0].metadata['Name'],
             config.version if config.version is not None else
-            packages[0].metadata['version'])
+            packages[0].metadata['Version'])
         builder.duration = config.duration
         if config.output is not None:
             builder.output = config.output.read()


### PR DESCRIPTION
Turns out "metadata.json" was a transitional file in a withdrawn PEP (426). The current standard PEP (566) is to use the RFC-822 style METADATA file.