### PR TITLE
Run stty sane on shutdown

### DIFF
--- a/piwheels/monitor/__init__.py
+++ b/piwheels/monitor/__init__.py
@@ -38,6 +38,7 @@ that are having issues (e.g. excessive resource consumption from a huge build)
 or terminate the master itself.
 """
 
+import os
 import sys
 from datetime import datetime, timedelta, timezone
 from time import sleep
@@ -115,6 +116,7 @@ class PiWheelsMonitor:
             self.loop.run()
         finally:
             ctx.close()
+            os.system('stty sane')
 
     def build_ui(self):
         """


### PR DESCRIPTION
Urwid doesn't seem to correctly reset the terminal under some
circumstances (e.g. running under tmux)