### PR TITLE
Skip deleted packages and versions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -310,6 +310,12 @@ def master_config(request, tmpdir):
     return config
 
 
+@pytest.fixture(scope='function')
+def dev_mode(request, master_config):
+    master_config.dev_mode = True
+    return master_config
+
+
 @pytest.fixture(scope='session')
 def zmq_context(request):
     context = transport.Context()


### PR DESCRIPTION
Close #135, close #166.

A significant proportion of PyPI's package / version list has been deleted. This should hopefully simplify the running of the build queue query a bit and save us a few empty directories in the simple index